### PR TITLE
0.2.4 (chore): whitelist dist dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "eth-chains",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Helper module for getting Ethereum chains info.",
   "author": "Taylor Dawson",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
   "license": "WTFPL",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "author": "Taylor Dawson",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "WTFPL",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Remove `.npmignore` and whitelist the `dist` dir so that it gets included in the published npm package.