### PR TITLE
Build 'dist' directory before publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "yarn.lock"
   ],
   "license": "WTFPL",
   "scripts": {
     "build": "tsc",
     "generate": "ts-node src/build.ts",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "prepack": "yarn build"
   },
-  "prepublish": "tsc",
   "dependencies": {
     "got": "^11.8.2"
   },


### PR DESCRIPTION
Little follow-up to the comments in https://github.com/taylorjdawson/eth-chains/pull/1

Version 0.2.4 has the `dist` directory, but version `0.3.4` doesn't. It seems the `prepublish` directive in `package.json` was in the wrong place. I've also changed `prepublish` to `prepack` because Yarn 2 doesn't support `prepublish`.

I've added `yarn.lock` to the distributed files to help `npm/yarn` with dependency resolution.